### PR TITLE
export the catfish environment to the runtime step

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -40,11 +40,8 @@ SELECTED_ENVIRONMENT=${CATFISH_ENVIRONMENT:-production}
 for env_dir in $BUILD_DIR/{catfish,etc/environments}/${SELECTED_ENVIRONMENT}; do
     if test -f ${env_dir}/env -a -f $ENV_DIR/?rocfile; then
         echo "Found config files in ${env_dir}"
-        cp ${env_dir}/env $BUILD_DIR/.env
         # ? matches any single character so we move either procfile or Procfile
         cp ${env_dir}/?rocfile $BUILD_DIR/Procfile 
-        # export the environment variables from the file to later buildpacks
-        sed 's/^/export /' ${env_dir}/env > "$BIN_DIR/../export"
         # set the environment variables from the file as defaults in the slug
         # uses the 'buildpack standard library' function https://github.com/heroku/buildpack-stdlib/blob/bff46f46fdd1d1cf4285ae0384ee42df8fa94414/stdlib.sh#L75-L80
         while read -ra line < ${env_dir}/env; do

--- a/bin/compile
+++ b/bin/compile
@@ -11,19 +11,8 @@ fi
 source /tmp/stdlib.sh
 # end standard library init.
 
-export_env_dir() {
-  env_dir=$3
-  blacklist_regex=${3:-'^(PATH|GIT_DIR|CPATH|CPPATH|LD_PRELOAD|LIBRARY_PATH)$'}
-  if [ -d "$env_dir" ]; then
-    for e in $(ls $env_dir); do
-      echo "$e" | grep -qvE "$blacklist_regex" &&
-      export "$e=$(cat $env_dir/$e)"
-      :
-    done
-  fi
-}
-
-export_env_dir $@
+# we can use the buildpack standard library to export the environment
+export-env $3
 
 BIN_DIR=$(cd $(dirname $0); pwd)
 BUILD_DIR=$1

--- a/bin/compile
+++ b/bin/compile
@@ -4,6 +4,13 @@
 
 set -e
 
+# The standard library. We use it later to set-default-env.
+if [[ ! -f  /tmp/stdlib.sh ]]; then
+  curl --retry 3 -s https://lang-common.s3.amazonaws.com/buildpack-stdlib/v2/stdlib.sh > /tmp/stdlib.sh
+fi
+source /tmp/stdlib.sh
+# end standard library init.
+
 export_env_dir() {
   env_dir=$3
   blacklist_regex=${3:-'^(PATH|GIT_DIR|CPATH|CPPATH|LD_PRELOAD|LIBRARY_PATH)$'}
@@ -21,16 +28,29 @@ export_env_dir $@
 BIN_DIR=$(cd $(dirname $0); pwd)
 BUILD_DIR=$1
 
+# required for set-default-env, cribbed from the python buildpack
+PROFILE_PATH="$BUILD_DIR/.profile.d/catfish.sh"
+EXPORT_PATH="$BIN_DIR/../export"
+export PROFILE_PATH EXPORT_PATH
+# end required for set-default-env
+
 # The default environment is production
 SELECTED_ENVIRONMENT=${CATFISH_ENVIRONMENT:-production}
 
-for ENV_DIR in $BUILD_DIR/{catfish,etc/environments}/${SELECTED_ENVIRONMENT}; do
-    if test -f $ENV_DIR/env -a -f $ENV_DIR/?rocfile; then
-        echo "Found config files in $ENV_DIR"
-        cp $ENV_DIR/env $BUILD_DIR/.env
+for env_dir in $BUILD_DIR/{catfish,etc/environments}/${SELECTED_ENVIRONMENT}; do
+    if test -f ${env_dir}/env -a -f $ENV_DIR/?rocfile; then
+        echo "Found config files in ${env_dir}"
+        cp ${env_dir}/env $BUILD_DIR/.env
         # ? matches any single character so we move either procfile or Procfile
-        cp $ENV_DIR/?rocfile $BUILD_DIR/Procfile 
-        sed 's/^/export /' $ENV_DIR/env > "$BIN_DIR/../export"
+        cp ${env_dir}/?rocfile $BUILD_DIR/Procfile 
+        # export the environment variables from the file to later buildpacks
+        sed 's/^/export /' ${env_dir}/env > "$BIN_DIR/../export"
+        # set the environment variables from the file as defaults in the slug
+        # uses the 'buildpack standard library' function https://github.com/heroku/buildpack-stdlib/blob/bff46f46fdd1d1cf4285ae0384ee42df8fa94414/stdlib.sh#L75-L80
+        while read -ra line < ${env_dir}/env; do
+            IFS='=' read -ra key value <<< "${line}"
+            set-default-env ${key} ${value}
+        done
         exit 0
     fi
 done


### PR DESCRIPTION
the variables were correctly exported to later buildpacks but were not
available at runtime - this was an oversight. adding them to the profile
with the heroku-provided buildpack standard library should fix this.