### PR TITLE
Fix syntax error in JQ package.json mangling

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -54,7 +54,7 @@ for env_dir in $BUILD_DIR/{catfish,etc/environments}/${SELECTED_ENVIRONMENT}; do
         # set python version from .python-version
         if test -f $BUILD_DIR/.python-version; then
             echo "populating runtime.txt with correct python version"
-            echo -n python > $BUILD_DIR/runtime.txt
+            echo -n python- > $BUILD_DIR/runtime.txt
             grep '[0-9.]*' $BUILD_DIR/.python-version >> $BUILD_DIR/runtime.txt
         fi
 

--- a/bin/compile
+++ b/bin/compile
@@ -50,22 +50,25 @@ for env_dir in $BUILD_DIR/{catfish,etc/environments}/${SELECTED_ENVIRONMENT}; do
                 set_default_env ${key} ${value}
             done < ${env_dir}/env
         fi
+        
+        # set python version from .python-version
+        if test -f .python-version; then
+            echo "populating runtime.txt with correct python version"
+            echo -n python > runtime.txt
+            grep '[0-9.]*' .python-version >> $BUILD_DIR/runtime.txt
+        fi
+
+        # automate nvm + postinstall hook for node build
+        if test -f .nvmrc; then
+            echo "adjusting package.json"
+            $JQ '{engines: {node: $version}, scripts: {postinstall: "npm run build"}} * .' --arg version $(cat .nvmrc) < package.json > package.json.updated
+            mv package.json.updated $BUILD_DIR/package.json
+        fi
+
         exit 0
     fi
 done
 echo "No acceptable environment found for ${SELECTED_ENVIRONMENT}"
 exit 1
 
-# set python version from .python-version
-if test -f .python-version; then
-    echo "populating runtime.txt with correct python version"
-    echo -n python > runtime.txt
-    grep '[0-9.]*' .python-version >> $BUILD_DIR/runtime.txt
-fi
 
-# automate nvm + postinstall hook for node build
-if test -f .nvmrc; then
-    echo "adjusting package.json"
-    $JQ '{engines: {node: $version}, scripts: {postinstall: "npm run build"}} * .' --arg version $(cat .nvmrc) < package.json > package.json.updated
-    mv package.json.updated $BUILD_DIR/package.json
-fi

--- a/bin/compile
+++ b/bin/compile
@@ -2,8 +2,6 @@
 
 [ "$BUILDPACK_XTRACE" ] && set -o xtrace
 
-echo "using branch of buildpack"
-
 set -e
 
 get_os() {

--- a/bin/compile
+++ b/bin/compile
@@ -58,4 +58,4 @@ exit 1
 [ -f .python-version ] && echo -n python > runtime.txt && grep '[0-9.]*' .python-version >> runtime.txt
 
 # automate nvm + postinstall hook for node build
-[ -f .nvmrc ] && ($JQ '{engines: {node: $version}, scripts: {postinstall: "npm run build"}} * .' --arg version $(cat .nvmrc) < package.json > package.json.updated) && mv package.json{.updated,}
+[ -f .nvmrc ] && ($JQ '{engines: {node: $version}, scripts: {postinstall: "npm run build"}} * .' --arg version $(cat .nvmrc) < package.json > package.json.updated) && mv package.json.updated $1/package.json

--- a/bin/compile
+++ b/bin/compile
@@ -52,17 +52,17 @@ for env_dir in $BUILD_DIR/{catfish,etc/environments}/${SELECTED_ENVIRONMENT}; do
         fi
         
         # set python version from .python-version
-        if test -f .python-version; then
+        if test -f $BUILD_DIR/.python-version; then
             echo "populating runtime.txt with correct python version"
-            echo -n python > runtime.txt
-            grep '[0-9.]*' .python-version >> $BUILD_DIR/runtime.txt
+            echo -n python > $BUILD_DIR/runtime.txt
+            grep '[0-9.]*' $BUILD_DIR/.python-version >> $BUILD_DIR/runtime.txt
         fi
 
         # automate nvm + postinstall hook for node build
-        if test -f .nvmrc; then
+        if test -f $BUILD_DIR/.nvmrc; then
             echo "adjusting package.json"
-            $JQ '{engines: {node: $version}, scripts: {postinstall: "npm run build"}} * .' --arg version $(cat .nvmrc) < package.json > package.json.updated
-            mv package.json.updated $BUILD_DIR/package.json
+            $JQ '{engines: {node: $version}, scripts: {postinstall: "npm run build"}} * .' --arg version $(cat $BUILD_DIR/.nvmrc) < $BUILD_DIR/package.json > $BUILD_DIR/package.json.updated
+            mv $BUILD_DIR/package.json.updated $BUILD_DIR/package.json
         fi
 
         exit 0

--- a/bin/compile
+++ b/bin/compile
@@ -55,7 +55,15 @@ echo "No acceptable environment found for ${SELECTED_ENVIRONMENT}"
 exit 1
 
 # set python version from .python-version
-[ -f .python-version ] && echo -n python > runtime.txt && grep '[0-9.]*' .python-version >> runtime.txt
+if test -f .python-version; then
+    echo "populating runtime.txt with correct python version"
+    echo -n python > runtime.txt
+    grep '[0-9.]*' .python-version >> $BUILD_DIR/runtime.txt
+fi
 
 # automate nvm + postinstall hook for node build
-[ -f .nvmrc ] && ($JQ '{engines: {node: $version}, scripts: {postinstall: "npm run build"}} * .' --arg version $(cat .nvmrc) < package.json > package.json.updated) && mv package.json.updated $1/package.json
+if test -f .nvmrc; then
+    echo "adjusting package.json"
+    $JQ '{engines: {node: $version}, scripts: {postinstall: "npm run build"}} * .' --arg version $(cat .nvmrc) < package.json > package.json.updated
+    mv package.json.updated $BUILD_DIR/package.json
+fi

--- a/bin/compile
+++ b/bin/compile
@@ -2,6 +2,8 @@
 
 [ "$BUILDPACK_XTRACE" ] && set -o xtrace
 
+echo "using branch of buildpack"
+
 set -e
 
 get_os() {

--- a/bin/compile
+++ b/bin/compile
@@ -58,4 +58,4 @@ exit 1
 [ -f .python-version ] && echo -n python > runtime.txt && grep '[0-9.]*' .python-version >> runtime.txt
 
 # automate nvm + postinstall hook for node build
-[ -f .nvmrc ] && ($JQ '{engines: {node: $version}, scripts: {postinstall: "npm run build"} * .' --arg version $(cat .nvmrc) < package.json > package.json.updated) && mv package.json{.updated,}
+[ -f .nvmrc ] && ($JQ '{engines: {node: $version}, scripts: {postinstall: "npm run build"}} * .' --arg version $(cat .nvmrc) < package.json > package.json.updated) && mv package.json{.updated,}


### PR DESCRIPTION
* The runtime.txt and package.json mangling wasn't actually happening at all, as it was after the `exit 0` that jumped out of the script when the env-dir fiddling was finished.
* There was a syntax error in the JQ command for mangling the package.json
* Made everything more verbose and less code-golf

This has been tested on a real build and really works.