### PR TITLE
Quote env vars when exporting

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -45,7 +45,7 @@ for env_dir in $BUILD_DIR/{catfish,etc/environments}/${SELECTED_ENVIRONMENT}; do
             # uses the 'buildpack standard library' function https://github.com/heroku/buildpack-stdlib/blob/bff46f46fdd1d1cf4285ae0384ee42df8fa94414/stdlib.sh#L75-L80
             while read line; do
                 IFS='=' read key value <<< "${line}"
-                set_default_env ${key} ${value}
+                set_default_env "${key}" "${value}"
             done < ${env_dir}/env
         fi
         exit 0


### PR DESCRIPTION
If there's a space in the env var value, this was blowing up.

Eg if the env var is

    DEFAULT_FROM_EMAIL="Conceptualizer Beta <donotreply@conceptualizer.dabdev.net>"

This was ending up in the profile as:

    export DEFAULT_FROM_EMAIL=${DEFAULT_FROM_EMAIL:-"Conceptualizer}

Which resulted in the following error:

    /app/.profile.d/catfish.sh: line 6: unexpected EOF while looking for matching `"'
    /app/.profile.d/catfish.sh: line 15: syntax error: unexpected end of file