### PR TITLE
Revert "Remove postinstall step from package.json"

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -59,7 +59,7 @@ for env_dir in $BUILD_DIR/{catfish,etc/environments}/${SELECTED_ENVIRONMENT}; do
         # automate nvm + postinstall hook for node build
         if test -f $BUILD_DIR/.nvmrc; then
             echo "adjusting package.json"
-            $JQ '{engines: {node: $version}} * .' --arg version $(cat $BUILD_DIR/.nvmrc) < $BUILD_DIR/package.json > $BUILD_DIR/package.json.updated
+            $JQ '{engines: {node: $version}, scripts: {postinstall: "npm run build"}} * .' --arg version $(cat $BUILD_DIR/.nvmrc) < $BUILD_DIR/package.json > $BUILD_DIR/package.json.updated
             mv $BUILD_DIR/package.json.updated $BUILD_DIR/package.json
         fi
 


### PR DESCRIPTION
Reverts dabapps/heroku-buildpack-catfish#15

It appears that heroku haven't turned this on yet 😞 